### PR TITLE
Group Anagrams

### DIFF
--- a/pullrequests/group_anagrams/step1.go
+++ b/pullrequests/group_anagrams/step1.go
@@ -8,7 +8,7 @@ package groupanagrams
 	配列のインデックスを用いて頻度を取得し、keyにすることにした。
 */
 
-func groupAnagrams_step1(strs []string) [][]string {
+func groupAnagramsStep1(strs []string) [][]string {
 	m := make(map[[26]int][]string)
 	for _, s := range strs {
 		var freq [26]int

--- a/pullrequests/group_anagrams/step1.go
+++ b/pullrequests/group_anagrams/step1.go
@@ -1,0 +1,28 @@
+//lint:file-ignore U1000 Ignore all unused code
+package groupanagrams
+
+/*
+	すぐに思いついたのはソートした文字列をkeyとしてハッシュテーブルを使ってグルーピングすること。
+	ただ、クイックソートの平均計算量はO(n log n)なので、O(n)でできればやりたいと思い、前に似た
+	ような問題を解いたことがあったので、与えられた条件に小文字しか使われないと書いてあったので、
+	配列のインデックスを用いて頻度を取得し、keyにすることにした。
+*/
+
+func groupAnagrams_step1(strs []string) [][]string {
+	m := make(map[[26]int][]string)
+	for _, s := range strs {
+		var freq [26]int
+		for _, r := range s {
+			freq[r-'a']++
+		}
+		m[freq] = append(m[freq], s)
+	}
+
+	result := make([][]string, len(m))
+	i := 0
+	for _, v := range m {
+		result[i] = v
+		i++
+	}
+	return result
+}

--- a/pullrequests/group_anagrams/step2.go
+++ b/pullrequests/group_anagrams/step2.go
@@ -1,0 +1,25 @@
+//lint:file-ignore U1000 Ignore all unused code
+package groupanagrams
+
+/*
+	変数名を改善した。
+*/
+
+func groupAnagrams_step2(strs []string) [][]string {
+	m := make(map[[26]int][]string)
+	for _, s := range strs {
+		var freq [26]int
+		for _, r := range s {
+			freq[r-'a']++
+		}
+		m[freq] = append(m[freq], s)
+	}
+
+	res := make([][]string, len(m))
+	i := 0
+	for _, v := range m {
+		res[i] = v
+		i++
+	}
+	return res
+}

--- a/pullrequests/group_anagrams/step2.go
+++ b/pullrequests/group_anagrams/step2.go
@@ -5,7 +5,7 @@ package groupanagrams
 	変数名を改善した。
 */
 
-func groupAnagrams_step2(strs []string) [][]string {
+func groupAnagramsStep2(strs []string) [][]string {
 	m := make(map[[26]int][]string)
 	for _, s := range strs {
 		var freq [26]int

--- a/pullrequests/group_anagrams/step3.go
+++ b/pullrequests/group_anagrams/step3.go
@@ -1,0 +1,31 @@
+//lint:file-ignore U1000 Ignore all unused code
+package groupanagrams
+
+/*
+	時間：3分
+	変数名をリファクタした。
+
+	質問：
+		- resという変数名をどう思いますか？
+		- mという変数名をどう思いますか？（mapのmです）
+		- wordsという変数名をどう思いますか？
+*/
+
+func groupAnagrams_step3(strs []string) [][]string {
+	m := make(map[[26]int][]string)
+	for _, word := range strs {
+		var freq [26]int
+		for _, r := range word {
+			freq[r-'a']++
+		}
+		m[freq] = append(m[freq], word)
+	}
+
+	res := make([][]string, len(m))
+	i := 0
+	for _, words := range m {
+		res[i] = words
+		i++
+	}
+	return res
+}

--- a/pullrequests/group_anagrams/step3.go
+++ b/pullrequests/group_anagrams/step3.go
@@ -11,7 +11,7 @@ package groupanagrams
 		- wordsという変数名をどう思いますか？
 */
 
-func groupAnagrams_step3(strs []string) [][]string {
+func groupAnagramsStep3(strs []string) [][]string {
 	m := make(map[[26]int][]string)
 	for _, word := range strs {
 		var freq [26]int

--- a/pullrequests/group_anagrams/step4.go
+++ b/pullrequests/group_anagrams/step4.go
@@ -1,0 +1,21 @@
+//lint:file-ignore U1000 Ignore all unused code
+package groupanagrams
+
+func groupAnagrams(strs []string) [][]string {
+	anagramsMap := make(map[[26]int][]string)
+	for _, word := range strs {
+		var frequency [26]int
+		for _, r := range word {
+			frequency[r-'a']++
+		}
+		anagramsMap[frequency] = append(anagramsMap[frequency], word)
+	}
+
+	anagrams := make([][]string, len(anagramsMap))
+	i := 0
+	for _, words := range anagramsMap {
+		anagrams[i] = words
+		i++
+	}
+	return anagrams
+}

--- a/pullrequests/group_anagrams/step5.go
+++ b/pullrequests/group_anagrams/step5.go
@@ -1,14 +1,14 @@
 //lint:file-ignore U1000 Ignore all unused code
 package groupanagrams
 
-func groupAnagramsStep4(strs []string) [][]string {
+func groupAnagramsStep5(strs []string) [][]string {
 	anagramsMap := make(map[[26]int][]string)
 	for _, word := range strs {
-		var frequency [26]int
+		var frequencies [26]int
 		for _, r := range word {
-			frequency[r-'a']++
+			frequencies[r-'a']++
 		}
-		anagramsMap[frequency] = append(anagramsMap[frequency], word)
+		anagramsMap[frequencies] = append(anagramsMap[frequencies], word)
 	}
 
 	anagrams := make([][]string, len(anagramsMap))


### PR DESCRIPTION
Group Anagramsを解きました。レビューお願いいたします。

言語：Go
問題：https://leetcode.com/problems/group-anagrams/description/

`anagrams := make([][]string, len(anagramsMap))`は、代わりに`anagrams := make([][]string, 0, len(anagramsMap))`として長さ0、容量`len(anagramsMap)`の`anagrams`を定義することで、`anagrams = append(anagrams, words)`と新たなメモリ割り当てをせずに書くことができる。

スライスは内部的には配列が使われていてそのポインタを移動させているだけなので、容量を指定すればその容量分の長さの配列が確保され、それを超えない限りは再度アロケーションされることはない。

実際に確かめるために下記のコードを実験してみる（[Go Playground](https://go.dev/play/)で簡単に実行できる）。出力結果を見ると、容量と配列の位置が変わらないのがわかる。

```
package main

import (
	"fmt"
	"unsafe"
)

func main() {
	s := make([]int, 0, 5)
	// var s []int
	printSlice(s)

	for i := 1; i <= 5; i++ {
		s = append(s, i)
		printSlice(s)
	}
}

func printSlice(s []int) {
	if len(s) > 0 {
		fmt.Printf("len=%d cap=%d address=%p %v\n", len(s), cap(s), unsafe.Pointer(&s[0]), s)
	} else {
		fmt.Printf("len=%d cap=%d address=nil %v\n", len(s), cap(s), s)
	}
}
```
```
len=0 cap=5 address=nil []
len=1 cap=5 address=0xc00011c000 [1]
len=2 cap=5 address=0xc00011c000 [1 2]
len=3 cap=5 address=0xc00011c000 [1 2 3]
len=4 cap=5 address=0xc00011c000 [1 2 3 4]
len=5 cap=5 address=0xc00011c000 [1 2 3 4 5]
```

対して、`var s []int`を使ってみると、容量が足りなくなるたびに倍の容量が新たに確保され、配列のアドレス位置も変わっていることがわかる。なのでこの場合は配列を新たに確保し、要素を新しい配列にコピーする形になる。

```
len=0 cap=0 address=nil []
len=1 cap=1 address=0xc000012060 [1]
len=2 cap=2 address=0xc000012070 [1 2]
len=3 cap=4 address=0xc00007c020 [1 2 3]
len=4 cap=4 address=0xc00007c020 [1 2 3 4]
len=5 cap=8 address=0xc00007e040 [1 2 3 4 5]
```

ちなみに、makeの引数に、mapを作る場合は型とキャパシティのヒントの２つのみを取ることができる。スライスを作る場合は型と長さとキャパシティのヒントの３つを取ることができる。