### PR TITLE
Two Sum

### DIFF
--- a/pullrequests/two_sum/step1.go
+++ b/pullrequests/two_sum/step1.go
@@ -6,7 +6,7 @@ package twosum
 
 また同じ要素を２回使うのを避けるために、毎回追加する前に対応する要素がないかを確認してから追加するようにしました。
 */
-func twoSum_step1(nums []int, target int) []int {
+func twoSumStep1(nums []int, target int) []int {
 	m := make(map[int]int)
 	for i, n := range nums {
 		if j, ok := m[target-n]; ok {

--- a/pullrequests/two_sum/step1.go
+++ b/pullrequests/two_sum/step1.go
@@ -1,0 +1,18 @@
+//lint:file-ignore U1000 Ignore all unused code
+package twosum
+
+/*
+かなり前に解いたものなので詳細は忘れてしまいましたが、ナイーブにやる方法では各文字ごとに毎回リストを走査してしまうと時間計算量がO(n^2)になってしまうので、オーバーヘッドはありますが、ハッシュ化するのが良いと考えました。
+
+また同じ要素を２回使うのを避けるために、毎回追加する前に対応する要素がないかを確認してから追加するようにしました。
+*/
+func twoSum_step1(nums []int, target int) []int {
+	m := make(map[int]int)
+	for i, n := range nums {
+		if j, ok := m[target-n]; ok {
+			return []int{i, j}
+		}
+		m[n] = i
+	}
+	return nil
+}

--- a/pullrequests/two_sum/step2.go
+++ b/pullrequests/two_sum/step2.go
@@ -13,7 +13,7 @@ GoogleのGoスタイルガイドには変数名に型名を使うのは良くな
   - https://github.com/seal-azarashi/leetcode/pull/11#discussion_r1672537855
   - https://github.com/sendahuang14/leetcode/pull/11#discussion_r1702393602
 */
-func twoSum_step2(nums []int, target int) []int {
+func twoSumStep2(nums []int, target int) []int {
 	numsMap := make(map[int]int)
 	for i, n := range nums {
 		if j, ok := numsMap[target-n]; ok {

--- a/pullrequests/two_sum/step2.go
+++ b/pullrequests/two_sum/step2.go
@@ -1,0 +1,25 @@
+//lint:file-ignore U1000 Ignore all unused code
+package twosum
+
+/*
+mではなく、よりわかりやすいようにnumsMapとしました。
+GoogleのGoスタイルガイドには変数名に型名を使うのは良くないと書かれていますが、同時に下記のようにも書かれています。今回はnumsという配列をマップに変換したもの（配列もインデックスと値を情報としてもつ）と捉えることができるため、対応していることを示すためにnumsMapとしました。
+
+`It is acceptable to include a type-like qualifier if there are two versions of a value in scope, for example you might have an input stored in ageString and use age for the parsed value.`
+
+`numToIdx`というのもありそう（https://github.com/aoshi2025s/leetcode-review/pull/1#discussion_r1666780953）。
+
+対応する組み合わせが見つからなかった際にどうするのかは難しいところ。
+  - https://github.com/seal-azarashi/leetcode/pull/11#discussion_r1672537855
+  - https://github.com/sendahuang14/leetcode/pull/11#discussion_r1702393602
+*/
+func twoSum_step2(nums []int, target int) []int {
+	numsMap := make(map[int]int)
+	for i, n := range nums {
+		if j, ok := numsMap[target-n]; ok {
+			return []int{i, j}
+		}
+		numsMap[n] = i
+	}
+	return nil
+}

--- a/pullrequests/two_sum/step3.go
+++ b/pullrequests/two_sum/step3.go
@@ -1,0 +1,13 @@
+//lint:file-ignore U1000 Ignore all unused code
+package twosum
+
+func twoSumStep3(nums []int, target int) []int {
+	numToIndex := make(map[int]int)
+	for i, n := range nums {
+		if j, ok := numToIndex[target-n]; ok {
+			return []int{i, j}
+		}
+		numToIndex[n] = i
+	}
+	return nil // 本来ならerrorを返したい
+}


### PR DESCRIPTION
Two Sumを解きました。レビューをお願いいたします。

問題：https://leetcode.com/problems/two-sum/
言語：Go

すでに解いている方々：
https://github.com/colorbox/leetcode/pull/3
https://github.com/Kitaken0107/GrindEasy/pull/4
https://github.com/sakupan102/arai60-practice/pull/12
https://github.com/goto-untrapped/Arai60/pull/2
https://github.com/kzhra/Grind41/pull/1
https://github.com/fhiyo/leetcode/pull/14
https://github.com/TORUS0818/leetcode/pull/13
https://github.com/erutako/leetcode/pull/2
https://github.com/Ryotaro25/leetcode_first60/pull/12
https://github.com/kazukiii/leetcode/pull/12
https://github.com/Yoshiki-Iwasa/Arai60/pull/10
https://github.com/aoshi2025s/leetcode-review/pull/1
https://github.com/seal-azarashi/leetcode/pull/11
https://github.com/sendahuang14/leetcode/pull/11

## Pythonにおける`{}` vs `dict()`
odaさんによると`dict()`よりも`{}`のほうがよく使われるとのこと。
https://github.com/su33331/practice/pull/2#discussion_r1615485637

また、Pylintでもdict()は追加の関数呼び出しが行われるので{}の方が速いため、dict()を使った際は{}を使うようにメッセージが出るようになっているっぽい。
https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-dict-literal.html
https://github.com/TORUS0818/leetcode/pull/13#discussion_r1626041770

## Goのエラー処理

### [error型](https://go.dev/doc/effective_go#errors)
Goには例外がなく、エラーを返り値（`error`型）として返すことが一般的である（[「例外」がないからGo言語はイケてないとかって言ってるヤツが本当にイケてない件](https://qiita.com/Maki-Daisuke/items/80cbc26ca43cca3de4e4)）。error型は下記のようにビルトインインターフェースとして定義されている。

```Go
type error interface {
    Error() string
}
```

可能であれば、エラー文字列は、エラーを発生させた操作やパッケージを示す接頭辞を持つなどして、その発生元を特定できるようにすべきである。 

`fmt.Errorf`は書式指定子に従って書式を設定し、`error`型を満たす値として文字列を返す（https://pkg.go.dev/fmt#Errorf ）。`fmt.Printf`と違って標準出力に書き込まれるわけではない。

### [log](https://pkg.go.dev/log)
`log.Panic`, `log.Fatal`, `log.Print`などは、標準エラーに書き込み、各ログメッセージの日付と時刻を表示する。 出力されるメッセージが改行で終わっていない場合、改行を追加する。 `Fatal`関数は、ログメッセージを書き込んだ後、`os.Exit(1)`を呼び出す。`Panic`関数は、ログメッセージを書き込んだ後に`panic`を呼び出す。

`log.Fatal`がログの出力とともにプログラムを異常終了するという設計になってる理由について、Googleではコードベースが巨大なために例外を使うとプログラムの処理を追うのが困難になってしまうため、異常が出たらすぐにプロセスを終了させたいらしく、その際に異常終了したデータも欲しいということでそのような設計になっているらしい（https://x.com/ainsophyao/status/1520934026626109440 ）。

### [Panic](https://go.dev/doc/effective_go#panic) / [Recover](https://go.dev/doc/effective_go#recover)
`panic`というビルトイン関数は、エラーが回復不能なものでプログラムの実行を継続できない場合に、プログラムの実行を停止するランタイムエラーを作り出す。`panic`は、任意の型の引数（多くの場合文字列）を1つ取り、プログラムが終了するときに表示される。 また、無限ループから抜けるなど、何か不可能なことが起こったことを示す手段でもある。

実際のライブラリ関数はパニックを避けるべきである。当たり前だが、もし問題を隠したり回避できるのであれば、プログラム全体をダウンさせるよりも、実行を継続させた方が良い。 もしライブラリが本当に実行を継続できないのであれば、パニックを起こすのは仕方がない。

`panic`が呼び出されると、スライスのインデックスが範囲外であるとか、型アサーションに失敗するといった実行時エラーに対して暗黙的に呼び出される場合も含めて、現在の関数の実行を直ちに停止し、ゴルーチンのスタックの巻き戻しを開始し、途中で遅延された関数を実行する。 巻き戻しがゴルーチンのスタックの最上位に達すると、プログラムは終了するが、ビルトイン関数の`recover`を使えば、ゴルーチンの制御を取り戻し、通常の実行を再開することができる。

`recover`の呼び出しは巻き戻しを停止し、`panic`に渡された引数を返す。 巻き戻し中に実行されるコードは遅延（deferred）関数の内部だけであるため、`recover`は遅延関数の内部でのみ有用である。

```Go
func safelyDo(work *Work) {
    defer func() {
        if err := recover(); err != nil {
            log.Println("work failed:", err)
        }
    }()
    do(work)
}
```