### PR TITLE
Combination Sum

### DIFF
--- a/pullrequests/combination_sum/step1.go
+++ b/pullrequests/combination_sum/step1.go
@@ -5,7 +5,7 @@ package template
 時間：24分
 少し前にバックトラッキングの問題を解いたので、ある条件を満たす全ての組み合わせを求めるためにバックトラッキングを使って解きました。
 */
-func combinationSum_step1(candidates []int, target int) [][]int {
+func combinationSumStep1(candidates []int, target int) [][]int {
 	var combinations [][]int
 	var stack []int
 	var findCombinations func(int, int)

--- a/pullrequests/combination_sum/step1.go
+++ b/pullrequests/combination_sum/step1.go
@@ -1,0 +1,30 @@
+//lint:file-ignore U1000 Ignore all unused code
+package template
+
+/*
+時間：24分
+少し前にバックトラッキングの問題を解いたので、ある条件を満たす全ての組み合わせを求めるためにバックトラッキングを使って解きました。
+*/
+func combinationSum_step1(candidates []int, target int) [][]int {
+	var combinations [][]int
+	var stack []int
+	var findCombinations func(int, int)
+	findCombinations = func(curr int, sum int) {
+		if sum == target {
+			combination := make([]int, len(stack))
+			copy(combination, stack)
+			combinations = append(combinations, combination)
+			return
+		}
+		if sum > target {
+			return
+		}
+		for i := curr; i < len(candidates); i++ {
+			stack = append(stack, candidates[i])
+			findCombinations(i, sum+candidates[i])
+			stack = stack[:len(stack)-1]
+		}
+	}
+	findCombinations(0, 0)
+	return combinations
+}

--- a/pullrequests/combination_sum/step2.go
+++ b/pullrequests/combination_sum/step2.go
@@ -1,0 +1,56 @@
+//lint:file-ignore U1000 Ignore all unused code
+package template
+
+/*
+Step1では再帰を使ってバックトラッキングを解いたので、スタックを使った方法も実装しました。
+また、Step1の実装のリファクタもしました。
+*/
+func combinationSum_backtracking_stack(candidates []int, target int) [][]int {
+	combinations := [][]int{}
+	type state struct {
+		combination []int
+		sum         int
+		index       int
+	}
+	stack := []state{{[]int{}, 0, 0}}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if current.sum == target {
+			combinations = append(combinations, append([]int{}, current.combination...))
+			continue
+		}
+		for i := current.index; i < len(candidates); i++ {
+			newSum := current.sum + candidates[i]
+			if newSum > target {
+				continue
+			}
+			newCombination := append([]int{}, current.combination...)
+			newCombination = append(newCombination, candidates[i])
+			stack = append(stack, state{newCombination, newSum, i})
+		}
+	}
+	return combinations
+}
+
+func combinationSum_backtracking_recursion(candidates []int, target int) [][]int {
+	var combinations [][]int
+	var stack []int
+	var generateCombinations func(int, int)
+	generateCombinations = func(currentIndex int, sum int) {
+		if sum == target {
+			combinations = append(combinations, append([]int{}, stack...))
+			return
+		}
+		if sum > target {
+			return
+		}
+		for i := currentIndex; i < len(candidates); i++ {
+			stack = append(stack, candidates[i])
+			generateCombinations(i, sum+candidates[i])
+			stack = stack[:len(stack)-1]
+		}
+	}
+	generateCombinations(0, 0)
+	return combinations
+}

--- a/pullrequests/combination_sum/step3.go
+++ b/pullrequests/combination_sum/step3.go
@@ -5,7 +5,7 @@ package template
 動的計画法を使った方法も実装しました。
 targetごとに組み合わせを求めると重複する組み合わせが生じてしまうので、candidateごとに組み合わせを求めるようにしました。
 */
-func combinationSum_dp(candidates []int, target int) [][]int {
+func combinationSumDP(candidates []int, target int) [][]int {
 	combinationsGroups := make([][][]int, target+1)
 	combinationsGroups[0] = [][]int{{}}
 	for _, candidate := range candidates {

--- a/pullrequests/combination_sum/step3.go
+++ b/pullrequests/combination_sum/step3.go
@@ -1,0 +1,21 @@
+//lint:file-ignore U1000 Ignore all unused code
+package template
+
+/*
+動的計画法を使った方法も実装しました。
+targetごとに組み合わせを求めると重複する組み合わせが生じてしまうので、candidateごとに組み合わせを求めるようにしました。
+*/
+func combinationSum_dp(candidates []int, target int) [][]int {
+	combinationsGroups := make([][][]int, target+1)
+	combinationsGroups[0] = [][]int{{}}
+	for _, candidate := range candidates {
+		for i := candidate; i <= target; i++ {
+			for _, combination := range combinationsGroups[i-candidate] {
+				newCombination := append([]int{}, combination...)
+				newCombination = append(newCombination, candidate)
+				combinationsGroups[i] = append(combinationsGroups[i], newCombination)
+			}
+		}
+	}
+	return combinationsGroups[target]
+}

--- a/pullrequests/combination_sum/step4.go
+++ b/pullrequests/combination_sum/step4.go
@@ -5,7 +5,7 @@ package template
 Step1では再帰を使ってバックトラッキングを解いたので、スタックを使った方法も実装しました。
 また、Step1の実装のリファクタもしました。
 */
-func combinationSumBacktrackingStack(candidates []int, target int) [][]int {
+func combinationSumBacktrackingStackStep4(candidates []int, target int) [][]int {
 	combinations := [][]int{}
 	type state struct {
 		combination []int
@@ -17,7 +17,7 @@ func combinationSumBacktrackingStack(candidates []int, target int) [][]int {
 		current := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
 		if current.sum == target {
-			combinations = append(combinations, append([]int{}, current.combination...))
+			combinations = append(combinations, current.combination)
 			continue
 		}
 		for i := current.index; i < len(candidates); i++ {
@@ -33,7 +33,7 @@ func combinationSumBacktrackingStack(candidates []int, target int) [][]int {
 	return combinations
 }
 
-func combinationSumBacktrackingRecursion(candidates []int, target int) [][]int {
+func combinationSumBacktrackingRecursionStep4(candidates []int, target int) [][]int {
 	var combinations [][]int
 	var stack []int
 	var generateCombinations func(int, int)


### PR DESCRIPTION
Combination Sumを解きました。レビューをお願いいたします。

問題：https://leetcode.com/problems/combination-sum/
言語：Go

下記は現在の私の理解について説明したものです。間違っている箇所や怪しい箇所があったらご指摘お願いいたします。

# バックトラッキング、動的計画法について
ある条件を満たす全ての組み合わせを求めるのに使われるアルゴリズムはブルートフォース、バックトラッキング、動的計画法の３つ。

## パフォーマンス
バックトラッキングは早期に枝刈りできるほど時間効率が良くなり、DPは同じ部分問題を繰り返し求める必要がある場合に効率的である。DPの空間計算量は $O(部分問題の数 \times 組み合わせ数)$ になり、バックトラッキングは $O(組み合わせ数)$ になる。そのため、バックトラッキングに比べてDPはメモリをより多く消費する傾向にある。

今回の実装では動的計画法の場合は、時間計算量は $O(len(candidates) \times target \times 組み合わせ数)$ 、空間計算量は $O(target \times 組み合わせ数)$ 。バックトラッキングの場合は、各`candidate`を選択するかしないかの２択になるため、時間計算量は $O(2^n)$ になる。空間計算量は $O(組み合わせ数)$ 。よって今回の問題の制約下ではDPの最悪時間計算量は $O(30 \times 40 \times 150)$ 、バックトラッキングは $O(2^{30})$ になるため、DPの方が良い？

# バックトラッキング
## 外側の変数を使って組み合わせを管理するか否か
バックトラッキングで再帰を使って書く場合、無名関数の外側の変数（`stack`）を使って組み合わせを構築するのではなく、再帰呼び出しをするたびに引数として構築中の組み合わせを渡す方法もとることはできるが、その場合は都度コピーしたものを渡していくことになるのでメモリ消費が大きくなるため、あえてこの方法を取るメリットはなさそう？

## スタックオーバーフローの可能性
バックトラッキングで再帰を使って書く場合、コールスタックに積まれるのは`generateCombinations`関数であり、`currentIndex`, `sum`, `i`（全てint型）を引数やローカル変数として持ち、戻り値は持たないため、64bitシステムの場合はint型は８B（64bit）であるため、8 * 3 = 24Bになる。またそのほかにもリターンアドレス、ベースポインタ（フレームポインタ）を持ち、それぞれ８Bであるため、16Bとなり[^3]、スタックフレームの全体サイズは約40Bになると考えることができる。また最悪の場合のコールスタックの深さは`target`に比例する（`target`に対して`candidate=1`を繰り返し選択する場合）。

今回の場合、`target`は40以下であるため、最大で40 * 40 = 1600B（1.6KB）になる。Goのスタックサイズは64bitの場合は1GB、32bitの場合は250MB[^4]なので、スタックオーバーフローを起こす可能性は低い。またgoroutineも[Go1.2のリリースノート](https://go.dev/doc/go1.2#stack_size)にはgoroutineのスタックサイズは8KBであると書かれている[^1]（[Go1.19のリリースノート](https://go.dev/doc/go1.19#runtime)によると過去のgoroutineが使用したスタックサイズの平均を使うように変更されたらしいが[^2]）ため、スタックオーバーフローを起こす可能性は低い。

Linuxスレッドのデフォルトスタックサイズは8MBほどであることから、goroutineのスタックサイズ（8KB）はとても小さいことがわかる。これにより、大量のgoroutineを高速に起動することができる（[Default stack size for pthreads](https://unix.stackexchange.com/questions/127602/default-stack-size-for-pthreads)、[スタックオーバーフローのハンドリング](https://www.nminoru.jp/~nminoru/programming/stackoverflow_handling.html)）。
    
ただし、どうやらgoroutineは、もし関数呼び出しで大きなサイズが必要なことがわかれば、別にスタックフレームを準備し、それに引数をコピーして、あたかもスタックがはじめて使われていたかのような状態で関数呼び出しを行うため、スタックサイズがギガバイトサイズになっても問題なく再帰ループを回すことができるらしく、動的にサイズが拡張されることから、スタックオーバーフローは通常のOSスレッドに比べて発生しにくくなる？（[Go言語のメモリ管理](https://ascii.jp/elem/000/001/496/1496211/)）

Goは、ランタイムのデフォルトスタックサイズが小さく、かつスタックサイズの大きさを最小にするような最適化を行っていないため、深さの数だけスタックを浪費する実装になっており、再帰の深さが極端に処理性能が落ちる要因になる（[Goで再帰使うと遅くなりますがそれが何だ](https://ymotongpoo.hatenablog.com/entry/2015/02/23/165341)）。そのため、「Goに慣れた人は自然と深い再帰処理はループ処理に書き換える」らしい（[Goの良さをまとめてみた](https://zenn.dev/nobonobo/articles/e651c66a15aaed657d6e#%E6%80%A7%E8%83%BD%E3%81%AFgo%E4%B8%AD%E7%B4%9A%E3%81%A7c++%E7%8E%84%E4%BA%BA%E3%81%AE9%E5%89%B2%E4%BB%A5%E4%B8%8A)）。なので今回の場合は再帰ではなくスタックを使って解く方がベター？

（Goのスタックサイズについて調べたとき、みんなgoroutineのスタックサイズの話をしているが、goroutineを使わない場合はGoはOSスレッドを使用しているということで良いのだろうか？つまりその場合はスタックサイズは8MBほどで考えれば良いということになるのだろうか？）

[^3]: SPやPCは現在の状態を示すものであり、各々のスタックフレームに含まれる性質のものではないため含まれない
[^1]: 4KBから8KBに拡張された。4KBではスタック領域が小さすぎて多くのプログラムで頻繁にスタックの拡張が発生し、その際のスタック領域スイッチング（新たにスタック領域を割り当て、もとのスタック領域からデータをコピーする）がパフォーマンスに悪影響を与えるためである
[^2]: 平均的なケースで、早期にスタック領域の拡張が行われ、それに伴うコピーが発生することを防ぐためだが、一方で平均以下のスタック領域しか使わないgoroutineでは最大で２倍のメモリが無駄になる可能性がある
[^4]: https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/runtime/proc.go#L120 / https://codereview.appspot.com/12541052/

# その他
コールスタックの深さについて：
デフォルトのコールスタックの深さはPythonだと1000、Javaだと１万ぐらい。https://discord.com/channels/1084280443945353267/1233603535862628432/1237744279363915878
https://github.com/Exzrgs/LeetCode/pull/13#discussion_r1606819961

Rustのデフォルトスタックサイズは2MB。
https://doc.rust-lang.org/std/thread/index.html#stack-size

DPを使ったPythonの実装：
https://github.com/fhiyo/leetcode/pull/52#issuecomment-2248269934

すでに解いた方々：
https://github.com/hayashi-ay/leetcode/pull/4
https://github.com/hayashi-ay/leetcode/pull/65
https://github.com/shining-ai/leetcode/pull/52
https://github.com/SuperHotDogCat/coding-interview/pull/11
https://github.com/goto-untrapped/Arai60/pull/15
https://github.com/Exzrgs/LeetCode/pull/13
https://github.com/nittoco/leetcode/pull/25
https://github.com/fhiyo/leetcode/pull/52